### PR TITLE
Most json-api schema fields are not required, only top level data

### DIFF
--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -21,7 +21,7 @@ defmodule PhoenixSwagger.JsonApi do
   alias PhoenixSwagger.Schema
 
   @doc """
-  Defines a schema for a paged list of results.
+  Defines a schema for a top level json-api document with an array of resources as primary data.
   This is used automatically from the JsonApi.resource macro is used.
   """
   def page(resource) do
@@ -36,8 +36,7 @@ defmodule PhoenixSwagger.JsonApi do
               type: :integer,
               description: "The total number of pages available"
             }
-          },
-          required: [:"total-pages"]
+          }
         },
         links: %Schema {
           type:  :object,
@@ -62,8 +61,7 @@ defmodule PhoenixSwagger.JsonApi do
               type:  :string,
               description:  "Link to the first page of results"
             }
-          },
-          required:  [:self, :prev, :next, :last, :first]
+          }
         },
         data: %Schema {
           type:  :array,
@@ -73,10 +71,14 @@ defmodule PhoenixSwagger.JsonApi do
           }
         }
       },
-      required:  [:meta, :links, :data]
+      required:  [:data]
     }
   end
 
+  @doc """
+  Defines a schema for a top level json-api document with a single primary data resource.
+  This is used automatically from the JsonApi.resource macro is used.
+  """
   def single(resource) do
     %Schema {
       type: :object,
@@ -89,8 +91,7 @@ defmodule PhoenixSwagger.JsonApi do
               type:  :string,
               description:  "the link that generated the current response document."
             }
-          },
-          required:  [:self]
+          }
         },
         data: %Schema {
           "$ref": "#/definitions/#{resource}"
@@ -101,7 +102,7 @@ defmodule PhoenixSwagger.JsonApi do
           items: %Schema{}
         }
       },
-      required:  [:links, :data]
+      required:  [:data]
     }
   end
 
@@ -213,7 +214,7 @@ defmodule PhoenixSwagger.JsonApi do
   end
 
   @doc """
-  Defines a relatioship
+  Defines a relationship
   """
   def relationship(model = %Schema{}, name) do
     put_in(

--- a/test/definition_test.exs
+++ b/test/definition_test.exs
@@ -15,6 +15,7 @@ defmodule PhoenixSwagger.JsonApiTest do
         user_created_at :string, "First created timestamp UTC"
         email :string, "Email", required: true
         birthday :string, "Birthday in YYYY-MM-DD format"
+        country :string, "Country"
         address Schema.ref(:Address)
       end
       link :self, "The link to this user resource"
@@ -53,7 +54,6 @@ defmodule PhoenixSwagger.JsonApiTest do
             "prev" => %{"description" => "Link to the previous page of results", "type" => "string"},
             "self" => %{"description" => "Link to this page of results", "type" => "string"}
           },
-          "required" => ["self", "prev", "next", "last", "first"],
           "type" => "object"
         },
         "meta" => %{
@@ -62,11 +62,10 @@ defmodule PhoenixSwagger.JsonApiTest do
               "description" => "The total number of pages available", "type" => "integer"
             }
           },
-          "required" => ["total-pages"],
           "type" => "object"
         }
       },
-      "required" => ["meta", "links", "data"],
+      "required" => ["data"],
       "type" => "object"
     }
   end
@@ -86,7 +85,6 @@ defmodule PhoenixSwagger.JsonApiTest do
               "type" => "string"
             }
           },
-          "required" => ["self"],
           "type" => "object"
         },
         "included" => %{
@@ -95,7 +93,7 @@ defmodule PhoenixSwagger.JsonApiTest do
           "items" => %{}
         }
       },
-      "required" => ["links", "data"],
+      "required" => ["data"],
       "type" => "object"
     }
   end


### PR DESCRIPTION
Allows validating responses against these schema in tests.