### PR TITLE
Paging parameters have minimum value = 1

### DIFF
--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -170,8 +170,8 @@ defmodule PhoenixSwagger.Path do
   """
   def paging(path = %PathObject{}, page_size_arg \\ "page[size]", page_num_arg \\ "page[number]") do
     path
-    |> parameter(page_size_arg, :query, :integer, "Number of elements per page")
-    |> parameter(page_num_arg, :query, :integer, "Number of the page")
+    |> parameter(page_size_arg, :query, :integer, "Number of elements per page", minimum: 1)
+    |> parameter(page_num_arg, :query, :integer, "Number of the page", minimum: 1)
   end
 
   @doc """

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -32,15 +32,16 @@ defmodule PhoenixSwagger.PathTest do
               "in" => "query",
               "name" => "page[size]",
               "required" => false,
-              "type" => "integer"
+              "type" => "integer",
+              "minimum" => 1
             },
             %{
-              "description" =>
-              "Number of the page",
+              "description" => "Number of the page",
               "in" => "query",
               "name" => "page[number]",
               "required" => false,
-              "type" => "integer"
+              "type" => "integer",
+              "minimum" => 1
             },
             %{
               "description" => "Gender of the user",


### PR DESCRIPTION
This will enable validation of paging parameters in phoenix applications.
Scrivener will throw an error if page number is <1 or page size <1.