### PR TITLE
Alias schema

### DIFF
--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -31,7 +31,7 @@ defmodule PhoenixSwagger do
   defmacro swagger_definitions([do: expr]) do
     quote do
       def swagger_definitions do
-        require PhoenixSwagger.JsonApi 
+        require PhoenixSwagger.JsonApi
         alias PhoenixSwagger.JsonApi
         alias PhoenixSwagger.Schema
         import PhoenixSwagger.Schema

--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -22,6 +22,7 @@ defmodule PhoenixSwagger do
       def swagger_definitions do
         require PhoenixSwagger.JsonApi
         alias PhoenixSwagger.JsonApi
+        alias PhoenixSwagger.Schema
         import PhoenixSwagger.Schema
         unquote(exprs) |> List.flatten |> Enum.into(%{}) |> Util.to_json
       end
@@ -32,6 +33,7 @@ defmodule PhoenixSwagger do
       def swagger_definitions do
         require PhoenixSwagger.JsonApi 
         alias PhoenixSwagger.JsonApi
+        alias PhoenixSwagger.Schema
         import PhoenixSwagger.Schema
         unquote(expr) |> Enum.into(%{}) |> Util.to_json
       end


### PR DESCRIPTION
This is so we can have embedded schemas inside of the `swagger_defintions` block.