### PR TITLE
Add support for JSON-API resources without pluralized form

### DIFF
--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -107,9 +107,9 @@ defmodule PhoenixSwagger.JsonApi do
   end
 
   @doc """
-  Defines schemas for a JSON-API resource, and a paginated list of results.
+  Defines schemas for a JSON-API resource, without a pluralized paginated version.
   """
-  defmacro resource(name, plural, expr) do
+  defmacro resource(name, expr) do
     resource_name = "#{name}Resource"
     quote do
       import unquote(__MODULE__)
@@ -134,7 +134,19 @@ defmodule PhoenixSwagger.JsonApi do
         {
           (unquote(name) |> to_string),
           single(unquote(resource_name))
-        },
+        }
+      ]
+    end
+  end
+
+  @doc """
+  Defines schemas for a JSON-API resource, with a pluralized paginated version.
+  """
+  defmacro resource(name, plural, expr) do
+    resource_name = "#{name}Resource"
+    quote do
+      import unquote(__MODULE__)
+      resource(unquote(name), unquote(expr)) ++ [
         {
           (unquote(plural) |> to_string),
           page(unquote(resource_name))

--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -11,7 +11,7 @@ defmodule PhoenixSwagger.Path do
       get "/users"
       produces "application/json"
       paging
-      parameter :id, :query, :integer, "user id", :required
+      parameter :id, :query, :integer, "user id", required: true
       tag "Users"
       response 200 "User resource" :User
       response 404 "User not found"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhoenixSwagger.Mixfile do
   def project do
     [app: :phoenix_swagger,
      version: "0.0.1",
-     elixir: "~> 1.1-dev",
+     elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps]

--- a/test/definition_test.exs
+++ b/test/definition_test.exs
@@ -22,6 +22,16 @@ defmodule PhoenixSwagger.JsonApiTest do
       relationship :posts
     end
 
+    JsonApi.resource(:Token) do
+      description "A security token."
+      attributes do
+        token :string, "The bearer token"
+        inserted_at :string, "First created timestamp UTC", format: "date-time"
+        updated_at :string, "Last update timestamp UTC", format: "date-time"
+      end
+      link :self, "The link to this user resource"
+    end
+
     {:Address, %Schema{
         type: "object",
         properties: %{
@@ -165,6 +175,63 @@ defmodule PhoenixSwagger.JsonApiTest do
           }
         }
       }
+    }
+  end
+
+  test "Plural resource is optional" do
+    assert swagger_definitions["Token"] == %{
+      "description" => "A JSON-API document with a single [TokenResource](#tokenresource) resource",
+      "properties" => %{
+        "data" => %{
+          "$ref" => "#/definitions/TokenResource"
+        },
+        "included" => %{
+          "description" => "Included resources",
+          "items" => %{},
+          "type" => "array"
+        },
+        "links" => %{
+          "properties" => %{
+            "self" => %{"description" => "the link that generated the current response document.", "type" => "string"}
+          },
+          "type" => "object"}
+        },
+        "required" => ["data"],
+        "type" => "object"
+      }
+
+    assert swagger_definitions["TokenResource"] == %{
+      "description" => "A security token.",
+      "properties" => %{
+        "attributes" => %{
+          "properties" =>
+          %{
+            "inserted_at" => %{"description" => "First created timestamp UTC", "format" => "date-time", "type" => "string"},
+            "token" => %{"description" => "The bearer token", "type" => "string"},
+            "updated_at" => %{"description" => "Last update timestamp UTC", "format" => "date-time", "type" => "string"}
+          },
+          "type" => "object"
+        },
+        "id" => %{
+          "description" => "The JSON-API resource ID", "type" => "string"
+        },
+        "links" => %{
+          "properties" => %{
+            "self" => %{
+              "description" => "The link to this user resource", "type" => "string"
+            }
+          },
+          "type" => "object"
+        },
+        "relationships" => %{
+          "properties" => %{},
+          "type" => "object"
+        },
+        "type" => %{
+          "description" => "The JSON-API resource type", "type" => "string"
+        }
+      },
+      "type" => "object"
     }
   end
 end

--- a/test/definition_test.exs
+++ b/test/definition_test.exs
@@ -15,7 +15,6 @@ defmodule PhoenixSwagger.JsonApiTest do
         user_created_at :string, "First created timestamp UTC"
         email :string, "Email", required: true
         birthday :string, "Birthday in YYYY-MM-DD format"
-        country :string, "Country"
         address Schema.ref(:Address)
       end
       link :self, "The link to this user resource"


### PR DESCRIPTION
See test for example with a singular security token.