### PR TITLE
Add command line option to specify router

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule PhoenixSwagger.Mixfile do
   defp deps do
     [
       {:credo, "~> 0.3", only: [:dev, :test]},
+      {:poison, "~> 2.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.4.1", "e67c65b89662675e7278b45c9dc4633e18797cf4481ebc5b47340ccbcfe721c9", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]}}
+  "credo": {:hex, :credo, "0.4.1", "e67c65b89662675e7278b45c9dc4633e18797cf4481ebc5b47340ccbcfe721c9", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}


### PR DESCRIPTION
This PR changes the behaviour of `phoenix.swagger.generate` to have better options parsing, and allow specifying a router module.

This also changes the behaviour to expect the swagger outline to be in the router module, not the mix.exs file.

```
-h --help: help
-o --output: output  file
-r --router: router module
```

This is basically the same approach as `mix phoenix.routes` which allows specifying a router to show the routes for.

