### PR TITLE
Add dsl for example parameter values

### DIFF
--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -159,10 +159,13 @@ defmodule PhoenixSwagger.Path do
       type: type,
       description: description
     }
-    param = Enum.reduce(opts, param, fn {k,v}, acc -> %{acc | k => v} end)
+    param = Map.merge(param, opts |> Enum.into(%{}, &translate_parameter_opt/1))
     params = path.operation.parameters
     put_in path.operation.parameters, params ++ [param]
   end
+
+  defp translate_parameter_opt({:example, v}), do: {:"x-example", v}
+  defp translate_parameter_opt({k, v}), do: {k, v}
 
   @doc """
   Adds page size and page number parameters to the operation of a swagger `%PathObject{}`

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -11,7 +11,7 @@ defmodule PhoenixSwagger.PathTest do
     produces "application/json"
     tag "Users"
     paging()
-    parameter("filter[gender]", "query", "string", "Gender of the user", required: true)
+    parameter("filter[gender]", "query", "string", "Gender of the user", required: true, example: "Male")
     response(200, "OK", Schema.ref(:Users))
     response(400, "Client Error")
   end
@@ -47,7 +47,8 @@ defmodule PhoenixSwagger.PathTest do
               "in" => "query",
               "name" => "filter[gender]",
               "required" => true,
-              "type" => "string"
+              "type" => "string",
+              "x-example" => "Male"
             }
           ],
           "responses" => %{


### PR DESCRIPTION
Usage:

``` Elixir
  parameter :state, :query, :string, "The state of Australia", example: "QLD"
```

Will translate to the "x-example" extension property for swagger parameter objects.
A few tools support this extension:
- https://help.apiary.io/api_101/swagger-extensions/#x-example
