### PR TITLE
Support array parameters with nested item types

### DIFF
--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -165,6 +165,9 @@ defmodule PhoenixSwagger.Path do
   end
 
   defp translate_parameter_opt({:example, v}), do: {:"x-example", v}
+  defp translate_parameter_opt({:items, items_schema}) when is_list(items_schema) do
+     {:items, Enum.into(items_schema, %{})}
+  end
   defp translate_parameter_opt({k, v}), do: {k, v}
 
   @doc """

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -11,7 +11,8 @@ defmodule PhoenixSwagger.PathTest do
     produces "application/json"
     tag "Users"
     paging()
-    parameter("filter[gender]", "query", "string", "Gender of the user", required: true, example: "Male")
+    parameter("filter[gender]", :query, :string, "Gender of the user", required: true, example: "Male")
+    parameter("include", :query, :array, "Relationships to include", items: [type: :string, enum: [:organisation, :favourites, :purchases]], collectionFormat: :csv)
     response(200, "OK", Schema.ref(:Users))
     response(400, "Client Error")
   end
@@ -49,6 +50,18 @@ defmodule PhoenixSwagger.PathTest do
               "required" => true,
               "type" => "string",
               "x-example" => "Male"
+            },
+            %{
+              "collectionFormat" => "csv",
+              "description" => "Relationships to include",
+              "in" => "query",
+              "items" => %{
+                "type" => "string",
+                "enum" => ["organisation", "favourites", "purchases"]
+              },
+              "name" => "include",
+              "required" => false,
+              "type" => "array"
             }
           ],
           "responses" => %{


### PR DESCRIPTION
Example:

```elixir
  parameter "include", :query, :array, "Relationships to include", items: [type: :string, enum: [:organisation, :favourites, :purchases]], collectionFormat: :csv
```