### PR TITLE
Use qualified module name when setting default operationId

### DIFF
--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -41,7 +41,7 @@ defmodule PhoenixSwagger do
         alias PhoenixSwagger.Schema
 
         unquote(body)
-        |> ensure_operation_id(__MODULE__, unquote(action))
+        |> PhoenixSwagger.ensure_operation_id(__MODULE__, unquote(action))
         |> nest
         |> Util.to_json
       end


### PR DESCRIPTION
 - Tests assume that the PhoenixSwagger module is imported
 - However some users of PhoenixSwagger may only be importing the swagger_path macro