### PR TITLE
Introduce schema definition DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ defmodule MyApp.UserController do
     response 200, "Success", :User
     tag "users"
   end
-  
+
   def show(conn, _params) do
     user = Repo.get!(MyApp.User, id)
     render(conn, "show.json", user: user)
@@ -167,6 +167,29 @@ This example adds 3 entries to the [definitions](http://swagger.io/specification
 
 Each line in the attributes block should contain `name`, `type`, `description`, `keyword-args`.
 The keyword args can contain any [Schema Object](http://swagger.io/specification/#schemaObject) fields.
+
+Schemas can also be defined outside of a `swagger_definitions` using `swagger_schema`.
+
+```elixir
+defmodule Example.Schema.User do
+  use PhoenixSwagger.SchemaDefinition
+
+  swagger_schema do
+    full_name, :string, "Full name"
+    email, :string, "Title", required: true
+    favorite_pizza, :string, "Favorite pizza", enum: [:pepperoni, :cheese, :supreme]
+    birthday, :datetime, "Birthday", format: :datetime
+  end
+end
+```
+
+The schema can then be added to the schema definitions for swagger.
+
+```elixir
+swagger_definitions do
+  User: Example.Schema.User.schema
+end
+```
 
 After this, run:
 

--- a/lib/phoenix_swagger/schema_definition.ex
+++ b/lib/phoenix_swagger/schema_definition.ex
@@ -1,0 +1,80 @@
+defmodule PhoenixSwagger.SchemaDefinition do
+  @moduledoc """
+  Provides a DSL to define Swagger Schemas outside of `swagger_definitions/1`. This separates the definition of a schema
+  from the placement inside of swagger.
+
+  # Example:
+
+  defmodule Example.Schemas.Book do
+    use PhoenixSwagger.SchemaDefinition
+
+    swagger_schema do
+      title :string, "Title", required: true
+      author :string, "Author", required: true
+    end
+  end
+  """
+  alias PhoenixSwagger.Schema
+
+  defmacro __using__(_opts) do
+    quote do
+      import PhoenixSwagger.SchemaDefinition
+    end
+  end
+
+  @doc """
+  This macro accepts a block where the schema is defined by listing the properties using a DSL.
+  Defining a property for the schema takes 2 required parameters and one optional parameter.
+
+  The first parameter is the name of the property.
+  The second parameter is the property type.
+  The third parameter is the description of the property.
+  The fourth optional parameter is an optional list of parameters that is passed to the PhoenixSwagger.Schema.
+
+  All these values are taken and placed into a PhoenixSwagger.Schema struct.
+
+  The PhoenixSwagger.Schema struct is returned from a `schema/0` function that is provided by this macro.
+
+  Example:
+    swagger_schema do
+      full_name, :string, "Full name"
+      title, :string, "Title", required: true
+      genre, :string, "Genre", enum: [:scifi, :horror, :drama, :comedy]
+      birthday, :datetime, "Birthday", format: :datetime
+    end
+  """
+  defmacro swagger_schema(properties_block) do
+    properties = case properties_block do
+      [do: {:__block__, _, info}] -> info
+      [do: info] -> [info]
+    end
+
+    properties = Enum.map(properties, &map_properties/1)
+
+    required = for {key, required, _} <- properties, required == true, do: key
+    properties = for {key, _, schema} <- properties, into: %{}, do: {key, schema}
+
+    quote do
+      def schema do
+        %Schema{
+          type: :object,
+          required: unquote(Macro.escape(required)),
+          properties: unquote(Macro.escape(properties))
+        }
+      end
+    end
+  end
+
+  defp map_properties({name, _, details}) do
+    [type, description, opts] = case details do
+      [type, description] -> [type, description, []]
+      [type, description, opts] -> [type, description, opts]
+    end
+
+    {
+      name,
+      opts[:required],
+      Schema.__struct__([type: type, description: description] ++ Keyword.delete(opts, :required))
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
-  @version "0.1.8"
+  @version "0.2.0"
 
   def project do
     [app: :edh_phoenix_swagger,

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule PhoenixSwagger.Mixfile do
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     elixirc_paths: elixirc_paths(Mix.env),
      deps: deps,
      package: package,
      docs: [extras: ["README.md"], main: "readme",
@@ -31,6 +32,10 @@ defmodule PhoenixSwagger.Mixfile do
   def application do
     [applications: [:logger]]
   end
+
+  # Specifies which paths to compile per environment
+  defp elixirc_paths(:test), do: ["lib", "test/schemas"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   # Dependencies can be Hex packages:
   #

--- a/test/schemas/book.ex
+++ b/test/schemas/book.ex
@@ -1,0 +1,8 @@
+defmodule PhoenixSwagger.Test.Schemas.Book do
+  use PhoenixSwagger.SchemaDefinition
+
+  swagger_schema do
+    title :string, "Title", required: true
+    author :string, "Author", required: true
+  end
+end

--- a/test/schemas/user.ex
+++ b/test/schemas/user.ex
@@ -1,0 +1,7 @@
+defmodule PhoenixSwagger.Test.Schemas.User do
+  use PhoenixSwagger.SchemaDefinition
+
+  swagger_schema do
+    full_name :string, "Full name"
+  end
+end

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -1,0 +1,47 @@
+defmodule PhoenixSwagger.JsonSchemaTest do
+  use ExUnit.Case
+  alias PhoenixSwagger.Schema
+  alias PhoenixSwagger.Test.Schemas.{User,Book}
+  import PhoenixSwagger
+
+  swagger_definitions do
+    [
+      User: User.schema,
+      Book: Book.schema,
+    ]
+  end
+
+  test "produces a User definition" do
+    user_schema = swagger_definitions["User"]
+
+    assert user_schema == %{
+      "type" => "object",
+      "required" => [],
+      "properties" => %{
+        "full_name" => %{
+          "description" => "Full name",
+          "type" => "string"
+        }
+      }
+    }
+  end
+
+  test "produces a Book definition" do
+    book_schema = swagger_definitions["Book"]
+
+    assert book_schema == %{
+      "type" => "object",
+      "required" => ["title", "author"],
+      "properties" => %{
+        "title" => %{
+          "description" => "Title",
+          "type" => "string"
+        },
+        "author" => %{
+          "description" => "Author",
+          "type" => "string"
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
This allows the creation of Swagger Schemas outside of the `swagger_definition/1` function.

You can then define swagger schemas in other modules / files separating their creation and maintenance from controllers.

Example:
```
defmodule Example.Schemas.Book do
  use PhoenixSwagger.SchemaDefinition

  swagger_schema_definition do
    title :string, "Title", required: true
    author :string, "Author", required: true
  end
end
```

You can then bring in the schema under a `swagger_definition/1` call.

```
  swagger_definitions do
    [
      Book: Example.Schemas.Book.schema,
    ]
  end
```