### PR TITLE
Add ability to reference another schema with DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ defmodule Example.Schema.User do
     favorite_pizza, :string, "Favorite pizza", enum: [:pepperoni, :cheese, :supreme]
     birthday, :datetime, "Birthday", format: :datetime
     address {:ref, :Address}, required: true
+    friends {:array, :User}, "Friends"
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ defmodule Example.Schema.User do
     email, :string, "Title", required: true
     favorite_pizza, :string, "Favorite pizza", enum: [:pepperoni, :cheese, :supreme]
     birthday, :datetime, "Birthday", format: :datetime
+    address {:ref, :Address}, required: true
   end
 end
 ```

--- a/lib/phoenix_swagger/schema_definition.ex
+++ b/lib/phoenix_swagger/schema_definition.ex
@@ -95,7 +95,7 @@ defmodule PhoenixSwagger.SchemaDefinition do
       opts[:required],
       Schema.__struct__([
         type: :array,
-        description: description,
+        description: get_description(description),
         items: Schema.ref(schema_name)
       ] ++ Keyword.delete(opts, :required))
     }
@@ -105,7 +105,13 @@ defmodule PhoenixSwagger.SchemaDefinition do
     {
       name,
       opts[:required],
-      Schema.__struct__([type: type, description: description] ++ Keyword.delete(opts, :required))
+      Schema.__struct__([
+        type: type,
+        description: get_description(description)
+      ] ++ Keyword.delete(opts, :required))
     }
   end
+
+  defp get_description({:sigil_S, _, [{_, _, [description]}, _]}), do: description
+  defp get_description(description), do: description
 end

--- a/lib/phoenix_swagger/schema_definition.ex
+++ b/lib/phoenix_swagger/schema_definition.ex
@@ -65,12 +65,14 @@ defmodule PhoenixSwagger.SchemaDefinition do
     end
   end
 
-  defp map_properties({name, _, details}) do
-    [type, description, opts] = case details do
-      [type, description] -> [type, description, []]
-      [type, description, opts] -> [type, description, opts]
-    end
+  defp map_properties({name, _, [{:ref, schema_name}, opts]}), do: schema_reference(name, opts[:required], schema_name)
+  defp map_properties({name, _, [ref: schema_name]}), do: schema_reference(name, false, schema_name)
+  defp map_properties({name, _, [type, description]}), do: schema_property(name, type, description, [])
+  defp map_properties({name, _, [type, description, opts]}), do: schema_property(name, type, description, opts)
 
+  defp schema_reference(name, required, schema_name), do: {name, required, Schema.ref(schema_name)}
+
+  defp schema_property(name, type, description, opts) do
     {
       name,
       opts[:required],

--- a/test/schemas/car.ex
+++ b/test/schemas/car.ex
@@ -1,0 +1,9 @@
+defmodule PhoenixSwagger.Test.Schemas.Car do
+  use PhoenixSwagger.SchemaDefinition
+
+  swagger_schema do
+    color :string, "Color", required: true
+    driver {:ref, :User}, required: true
+    passenger {:ref, :User}
+  end
+end

--- a/test/schemas/car.ex
+++ b/test/schemas/car.ex
@@ -3,7 +3,10 @@ defmodule PhoenixSwagger.Test.Schemas.Car do
 
   swagger_schema do
     color :string, "Color", required: true
-    driver {:ref, :User}, required: true
-    passenger {:ref, :User}
+    engine {:ref, :Engine}, required: true
+    driver {:ref, :User}
+    passengers {:array, :User}, "Passengers in car"
+    wheels {:array, :Wheel}, required: true
+    cargo {:array, :Luggage}
   end
 end

--- a/test/schemas/user.ex
+++ b/test/schemas/user.ex
@@ -3,5 +3,6 @@ defmodule PhoenixSwagger.Test.Schemas.User do
 
   swagger_schema do
     full_name :string, "Full name"
+    suffix :string, ~S'Name suffix</p>Example "Sr", "Jr"'
   end
 end

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -1,13 +1,14 @@
 defmodule PhoenixSwagger.JsonSchemaTest do
   use ExUnit.Case
   alias PhoenixSwagger.Schema
-  alias PhoenixSwagger.Test.Schemas.{User,Book}
+  alias PhoenixSwagger.Test.Schemas.{Book,Car,User}
   import PhoenixSwagger
 
   swagger_definitions do
     [
       User: User.schema,
       Book: Book.schema,
+      Car: Car.schema
     ]
   end
 
@@ -40,6 +41,27 @@ defmodule PhoenixSwagger.JsonSchemaTest do
         "author" => %{
           "description" => "Author",
           "type" => "string"
+        }
+      }
+    }
+  end
+
+  test "produces a Car definition" do
+    car_schema = swagger_definitions["Car"]
+
+    assert car_schema == %{
+      "type" => "object",
+      "required" => ["color", "driver"],
+      "properties" => %{
+        "color" => %{
+          "description" => "Color",
+          "type" => "string"
+        },
+        "driver" => %{
+          "$ref" => "#/definitions/User"
+        },
+        "passenger" => %{
+          "$ref" => "#/definitions/User"
         }
       }
     }

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -21,6 +21,10 @@ defmodule PhoenixSwagger.JsonSchemaTest do
         "full_name" => %{
           "description" => "Full name",
           "type" => "string"
+        },
+        "suffix" => %{
+          "description" => ~S'Name suffix</p>Example "Sr", "Jr"',
+          "type" => "string"
         }
       }
     }

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -17,7 +17,6 @@ defmodule PhoenixSwagger.JsonSchemaTest do
 
     assert user_schema == %{
       "type" => "object",
-      "required" => [],
       "properties" => %{
         "full_name" => %{
           "description" => "Full name",
@@ -72,7 +71,10 @@ defmodule PhoenixSwagger.JsonSchemaTest do
         },
         "passengers" => %{
           "description" => "Passengers in car",
-          "type" => {:array, :User}
+          "items" => %{
+            "$ref" => "#/definitions/User"
+          },
+          "type" => "array"
         },
         "wheels" => %{
           "description" => "",

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -51,7 +51,7 @@ defmodule PhoenixSwagger.JsonSchemaTest do
 
     assert car_schema == %{
       "type" => "object",
-      "required" => ["color", "driver"],
+      "required" => ["color", "engine", "wheels"],
       "properties" => %{
         "color" => %{
           "description" => "Color",
@@ -60,8 +60,26 @@ defmodule PhoenixSwagger.JsonSchemaTest do
         "driver" => %{
           "$ref" => "#/definitions/User"
         },
-        "passenger" => %{
-          "$ref" => "#/definitions/User"
+        "engine" => %{
+          "$ref" => "#/definitions/Engine"
+        },
+        "cargo" => %{
+          "description" => "",
+          "items" => %{
+            "$ref" => "#/definitions/Luggage"
+          },
+          "type" => "array"
+        },
+        "passengers" => %{
+          "description" => "Passengers in car",
+          "type" => {:array, :User}
+        },
+        "wheels" => %{
+          "description" => "",
+          "items" => %{
+            "$ref" => "#/definitions/Wheel"
+          },
+          "type" => "array"
         }
       }
     }


### PR DESCRIPTION
```elixir
defmodule Example.Schema.User do
  use PhoenixSwagger.SchemaDefinition

  swagger_schema do
    full_name, :string, "Full name"
    email, :string, "Title", required: true
    favorite_pizza, :string, "Favorite pizza", enum: [:pepperoni, :cheese, :supreme]
    birthday, :datetime, "Birthday", format: :datetime
    address {:ref, :Address}
    friends {:array, :User}, "Friends"
  end
end
```