### PR TITLE
Elixir 1.4 compat and update dependencies

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -29,14 +29,14 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
 
   def run(args) do
     Mix.Task.reenable("phoenix.swagger.generate")
-    Code.append_path(ebin)
+    Code.append_path(ebin())
     {switches, _params, _unknown} = OptionParser.parse(
       args,
       switches: [output: :string, router: :string, help: :boolean],
       aliases: [o: :output, r: :router, h: :help])
 
     if (Keyword.get(switches, :help)) do
-      usage
+      usage()
     else
       output_file = Keyword.get(switches, :output, @default_swagger_file_path)
       router = load_router(switches)
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
   defp load_router(switches) do
     {:module, router} =
       switches
-      |> Keyword.get(:router, default_router_module)
+      |> Keyword.get(:router, default_router_module())
       |> List.wrap
       |> Module.concat()
       |> Code.ensure_loaded()
@@ -83,7 +83,7 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
   end
 
   defp collect_host(swagger_map) do
-    endpoint_config = Application.get_env(app_name, Module.concat([app_module, :Endpoint]))
+    endpoint_config = Application.get_env(app_name(), Module.concat([app_module(), :Endpoint]))
 
     url = Keyword.get(endpoint_config, :url, [host: "localhost", port: @default_port])
     host = Keyword.get(url, :host, "localhost")
@@ -169,11 +169,11 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
   end
 
   defp default_router_module do
-    Module.concat([app_module, :Router])
+    Module.concat([app_module(), :Router])
   end
 
   defp ebin do
-    "#{@app_path}_build/#{Mix.env}/lib/#{app_name}/ebin"
+    "#{@app_path}_build/#{Mix.env}/lib/#{app_name()}/ebin"
   end
 
   defp default_outline do

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule PhoenixSwagger.Mixfile do
       {:credo, "~> 0.3", only: [:dev, :test]},
       {:ex_doc, ">= 0.13.0", only: :dev},
       {:inch_ex, only: :docs},
-      {:poison, "~> 2.0"}
+      {:poison, "~> 3.0"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,8 +10,8 @@ defmodule PhoenixSwagger.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      elixirc_paths: elixirc_paths(Mix.env),
-     deps: deps,
-     package: package,
+     deps: deps(),
+     package: package(),
      docs: [extras: ["README.md"], main: "readme",
               source_ref: "#{@version}",
               source_url: "https://github.com/everydayhero/phoenix_swagger"]]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.4.1", "e67c65b89662675e7278b45c9dc4633e18797cf4481ebc5b47340ccbcfe721c9", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "inch_ex": {:hex, :inch_ex, "0.5.3", "39f11e96181ab7edc9c508a836b33b5d9a8ec0859f56886852db3d5708889ae7", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+  "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}

--- a/test/definition_test.exs
+++ b/test/definition_test.exs
@@ -46,7 +46,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   end
 
   test "produces expected paginated users schema" do
-    users_schema = swagger_definitions["Users"]
+    users_schema = swagger_definitions()["Users"]
     assert users_schema == %{
       "description" => "A page of [UserResource](#userresource) results",
       "properties" => %{
@@ -83,7 +83,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   end
 
   test "produces expected user top level schema" do
-    user_schema = swagger_definitions["User"]
+    user_schema = swagger_definitions()["User"]
     assert user_schema == %{
       "description" => "A JSON-API document with a single [UserResource](#userresource) resource",
       "properties" => %{
@@ -111,7 +111,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   end
 
   test "produces expected address schema" do
-    address_resource_schema = swagger_definitions["Address"]
+    address_resource_schema = swagger_definitions()["Address"]
     assert address_resource_schema == %{
       "properties" => %{
         "country" => %{"description" => "Country", "type" => "string"},
@@ -126,7 +126,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   end
 
   test "produces expected user resource schema" do
-    user_resource_schema = swagger_definitions["UserResource"]
+    user_resource_schema = swagger_definitions()["UserResource"]
     assert user_resource_schema == %{
       "description" => "A user that may have one or more supporter pages.",
       "type" => "object",
@@ -181,7 +181,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   end
 
   test "Plural resource is optional" do
-    assert swagger_definitions["Token"] == %{
+    assert swagger_definitions()["Token"] == %{
       "description" => "A JSON-API document with a single [TokenResource](#tokenresource) resource",
       "properties" => %{
         "data" => %{
@@ -202,7 +202,7 @@ defmodule PhoenixSwagger.JsonApiTest do
         "type" => "object"
       }
 
-    assert swagger_definitions["TokenResource"] == %{
+    assert swagger_definitions()["TokenResource"] == %{
       "description" => "A security token.",
       "properties" => %{
         "attributes" => %{

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -30,7 +30,7 @@ defmodule PhoenixSwagger.PathTest do
   end
 
    test "swagger_path_index produces expected swagger json" do
-    assert swagger_path_index == %{
+    assert swagger_path_index() == %{
       "/api/v1/users" => %{
         "get" => %{
           "produces" => ["application/json"],
@@ -93,7 +93,7 @@ defmodule PhoenixSwagger.PathTest do
   end
 
   test "swagger_path_create produces expected swagger json" do
-    assert swagger_path_create == %{
+    assert swagger_path_create() == %{
       "/api/v1/{team}/users" => %{
         "post" => %{
           "consumes" => ["application/json"],

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -13,7 +13,7 @@ defmodule PhoenixSwagger.JsonSchemaTest do
   end
 
   test "produces a User definition" do
-    user_schema = swagger_definitions["User"]
+    user_schema = swagger_definitions()["User"]
 
     assert user_schema == %{
       "type" => "object",
@@ -31,7 +31,7 @@ defmodule PhoenixSwagger.JsonSchemaTest do
   end
 
   test "produces a Book definition" do
-    book_schema = swagger_definitions["Book"]
+    book_schema = swagger_definitions()["Book"]
 
     assert book_schema == %{
       "type" => "object",
@@ -50,7 +50,7 @@ defmodule PhoenixSwagger.JsonSchemaTest do
   end
 
   test "produces a Car definition" do
-    car_schema = swagger_definitions["Car"]
+    car_schema = swagger_definitions()["Car"]
 
     assert car_schema == %{
       "type" => "object",


### PR DESCRIPTION
This PR has two changes.
1. Add parenthesis to satisfy elixir 1.4 parenthesis warnings.
2. Update dependencies, especially :poison from 2.0 to 3.0